### PR TITLE
Fix 'Box could not be found' issue in build-phar.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ A command-line interface (CLI) tool for managing JFrog Artifactory instances, su
 
 To build the PHAR file for the Compuzign-Artifactory-CLI, follow these steps:
 
-1. Ensure you have [Box](https://github.com/box-project/box) installed. If not, you can install it by following the instructions on the Box GitHub page.
+1. Ensure you have [Box](https://github.com/box-project/box) installed via Composer. If not, you can install it by running:
+
+    ```bash
+    composer require --dev humbug/box
+    ```
+
 2. Run the following command to generate the PHAR file:
 
     ```bash

--- a/scripts/build-phar.sh
+++ b/scripts/build-phar.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 # Ensure Box is installed
-if ! command -v box &> /dev/null
-then
+if ! [ -x "vendor/bin/box" ]; then
     echo "Box could not be found. Please install Box to proceed."
     exit
 fi
 
 # Generate the PHAR file using Box
-box compile
+vendor/bin/box compile


### PR DESCRIPTION
Fixes #5

Update `build-phar.sh` script to use `vendor/bin/box` for Box command

* Modify `scripts/build-phar.sh` to check for `vendor/bin/box` instead of a globally installed `box` command.
* Update `scripts/build-phar.sh` to use `vendor/bin/box compile` for generating the PHAR file.
* Update `README.md` to specify using `vendor/bin/box` for building the PHAR file and remove the instruction to ensure Box is installed globally.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hacker-prime/Compuzign-Artifactory-CLI/pull/6?shareId=73303af5-c874-43fe-a9e2-ecd85976d35c).