### PR TITLE
Implement user:delete command to remove a user from Artifactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,10 @@ Once you have built the PHAR file, you can use it to run the CLI commands. Here 
     php compuzign-artifactory-cli.phar user:create <username> <password> <email> [--admin]
     ```
 
+6. Delete a user:
+
+    ```bash
+    php compuzign-artifactory-cli.phar user:delete <username>
+    ```
+
 For more information on available commands, you can use the `help` command as shown above.

--- a/src/Command/DeleteUserCommand.php
+++ b/src/Command/DeleteUserCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\ArtifactoryAuthService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DeleteUserCommand extends Command
+{
+    protected static $defaultName = 'user:delete';
+
+    private $authService;
+
+    public function __construct(ArtifactoryAuthService $authService)
+    {
+        parent::__construct();
+        $this->authService = $authService;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Delete a user from Artifactory.')
+            ->addArgument('username', InputArgument::REQUIRED, 'The username of the user to be deleted.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $username = $input->getArgument('username');
+        $baseUrl = $_ENV['ARTIFACTORY_BASE_URL

--- a/src/Service/ArtifactoryAuthService.php
+++ b/src/Service/ArtifactoryAuthService.php
@@ -98,7 +98,30 @@ class ArtifactoryAuthService
             throw new \Exception("User creation failed [HTTP {$statusCode}]: {$errorMessage}");
         }
     }
-    
-}
 
+    public function deleteUser($username, $baseUrl)
+    {
+        $token = $this->getToken();
+        $url = rtrim($baseUrl, '/') . '/artifactory/api/security/users/' . $username;
+
+        try {
+            $response = $this->client->delete($url, [
+                'headers' => [
+                    'Authorization' => "Bearer {$token}",
+                    'Content-Type' => 'application/json'
+                ]
+            ]);
+
+            if ($response->getStatusCode() === 204) {
+                return "User '{$username}' deleted successfully.";
+            }
+
+            throw new \Exception('User deletion failed: ' . $response->getReasonPhrase());
+        } catch (RequestException $e) {
+            $statusCode = $e->getResponse() ? $e->getResponse()->getStatusCode() : 'unknown';
+            $errorMessage = $e->getResponse() ? $e->getResponse()->getBody()->getContents() : $e->getMessage();
+            throw new \Exception("User deletion failed [HTTP {$statusCode}]: {$errorMessage}");
+        }
+    }
+}
 ?>


### PR DESCRIPTION
Related to #11

Implement `user:delete` command to delete a user from Artifactory.

* **Add `DeleteUserCommand` class:**
  - Create `src/Command/DeleteUserCommand.php` to handle the `user:delete` command.
  - Use `ArtifactoryAuthService` to perform the delete operation.
  - Validate that `ARTIFACTORY_BASE_URL` is set in the `.env` file.
  - Handle API responses and display success or error messages.

* **Modify `ArtifactoryAuthService`:**
  - Add `deleteUser` method to handle the DELETE request to the Artifactory API.
  - Use the stored token for authentication in the `deleteUser` method.
  - Handle API responses and throw exceptions for errors in the `deleteUser` method.

* **Update `README.md`:**
  - Add instructions for running the `user:delete` command.
  - Include an example usage of the `user:delete` command.

