### PR TITLE
Implement `system:version` command to display Artifactory system version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,10 @@ Once you have built the PHAR file, you can use it to run the CLI commands. Here 
     php compuzign-artifactory-cli.phar user:delete <username>
     ```
 
+7. Retrieve and display the Artifactory system version:
+
+    ```bash
+    php compuzign-artifactory-cli.phar system:version
+    ```
+
 For more information on available commands, you can use the `help` command as shown above.

--- a/src/Command/SystemVersionCommand.php
+++ b/src/Command/SystemVersionCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\ArtifactoryAuthService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SystemVersionCommand extends Command
+{
+    protected static $defaultName = 'system:version';
+
+    private $authService;
+
+    public function __construct(ArtifactoryAuthService $authService)
+    {
+        parent::__construct();
+        $this->authService = $authService;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Retrieve and display the Artifactory system version.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $baseUrl = $_ENV['ARTIFACTORY_BASE_URL'];
+
+        if (!$baseUrl) {
+            $output->writeln("<error>Artifactory Base URL is not set. Please set the ARTIFACTORY_BASE_URL environment variable.</error>");
+            return Command::FAILURE;
+        }
+
+        try {
+            $versionInfo = $this->authService->getSystemVersion($baseUrl);
+            $output->writeln("<info>Artifactory System Version: {$versionInfo['version']}</info>");
+            $output->writeln("<info>Revision: {$versionInfo['revision']}</info>");
+        } catch (\Exception $e) {
+            $output->writeln("<error>Failed to retrieve system version: {$e->getMessage()}</error>");
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Service/ArtifactoryAuthService.php
+++ b/src/Service/ArtifactoryAuthService.php
@@ -128,7 +128,34 @@ class ArtifactoryAuthService
             throw new \Exception("User deletion failed [HTTP {$statusCode}]: {$errorMessage}");
         }
     }
-    
-    
+
+    public function getSystemVersion($baseUrl)
+    {
+        $token = $this->getToken();
+        $url = rtrim($baseUrl, '/') . '/artifactory/api/system/version';
+
+        try {
+            $response = $this->client->get($url, [
+                'headers' => [
+                    'Authorization' => "Bearer {$token}",
+                    'Content-Type' => 'application/json'
+                ]
+            ]);
+
+            if ($response->getStatusCode() === 200) {
+                $data = json_decode($response->getBody(), true);
+                return [
+                    'version' => $data['version'],
+                    'revision' => $data['revision']
+                ];
+            }
+
+            throw new \Exception('Failed to retrieve system version: ' . $response->getReasonPhrase());
+        } catch (RequestException $e) {
+            $statusCode = $e->getResponse() ? $e->getResponse()->getStatusCode() : 'unknown';
+            $errorMessage = $e->getResponse() ? $e->getResponse()->getBody()->getContents() : $e->getMessage();
+            throw new \Exception("Failed to retrieve system version [HTTP {$statusCode}]: {$errorMessage}");
+        }
+    }
 }
 ?>


### PR DESCRIPTION
Related to #13

Add `system:version` command to retrieve and display Artifactory system version.

* Add `SystemVersionCommand` class in `src/Command/SystemVersionCommand.php` to implement the `system:version` command.
* Add method `getSystemVersion` in `ArtifactoryAuthService` to retrieve the Artifactory system version.
* Update `README.md` to include instructions for running the `system:version` command.
* Validate `ARTIFACTORY_BASE_URL` in the `.env` file and handle API responses for success and failure.

